### PR TITLE
Return target_store to enable testing/logging stages after StoreToZarr

### DIFF
--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -468,4 +468,4 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
         target_store = schema | PrepareZarrTarget(
             target=self.get_full_target(), target_chunks=target_chunks
         )
-        return rechunked_datasets | StoreDatasetFragments(target_store=target_store)
+        return rechunked_datasets | StoreDatasetFragments(target_store=target_store) | beam.create([target_store])

--- a/pangeo_forge_recipes/transforms.py
+++ b/pangeo_forge_recipes/transforms.py
@@ -468,4 +468,5 @@ class StoreToZarr(beam.PTransform, ZarrWriterMixin):
         target_store = schema | PrepareZarrTarget(
             target=self.get_full_target(), target_chunks=target_chunks
         )
-        return rechunked_datasets | StoreDatasetFragments(target_store=target_store) | beam.create([target_store])
+        rechunked_datasets | StoreDatasetFragments(target_store=target_store)
+        return target_store

--- a/pangeo_forge_recipes/writers.py
+++ b/pangeo_forge_recipes/writers.py
@@ -68,7 +68,7 @@ def _is_first_in_merge_dim(index):
 
 def store_dataset_fragment(
     item: Tuple[Index, xr.Dataset], target_store: zarr.storage.FSStore
-) -> None:
+) -> zarr.storage.FSStore:
     """Store a piece of a dataset in a Zarr store.
 
     :param item: The index and dataset to be stored
@@ -89,6 +89,8 @@ def store_dataset_fragment(
                 _store_data(vname, da.variable, index, zgroup)
     for vname, da in ds.data_vars.items():
         _store_data(vname, da.variable, index, zgroup)
+    
+    return target_store 
 
 
 def write_combined_reference(

--- a/pangeo_forge_recipes/writers.py
+++ b/pangeo_forge_recipes/writers.py
@@ -68,7 +68,7 @@ def _is_first_in_merge_dim(index):
 
 def store_dataset_fragment(
     item: Tuple[Index, xr.Dataset], target_store: zarr.storage.FSStore
-) -> zarr.storage.FSStore:
+) -> None:
     """Store a piece of a dataset in a Zarr store.
 
     :param item: The index and dataset to be stored
@@ -89,8 +89,6 @@ def store_dataset_fragment(
                 _store_data(vname, da.variable, index, zgroup)
     for vname, da in ds.data_vars.items():
         _store_data(vname, da.variable, index, zgroup)
-    
-    return target_store 
 
 
 def write_combined_reference(


### PR DESCRIPTION
Very much WIP. I am trying to return a singular element containing the store that was just written to. What I am currently trying here is producing multiple outputs (I guess one per fragment written?). 
@cisaacstern do you have any clever ideas to do this? I think it would open a host of functionality like testing and logging of successfully written stores. 